### PR TITLE
Uso del setState como callback

### DIFF
--- a/imports/ui/components/EnterForm.jsx
+++ b/imports/ui/components/EnterForm.jsx
@@ -22,8 +22,8 @@ export default class EnterForm extends Component {
 	changeLog(e) {
 		e.preventDefault();
 
-		this.setState({
-			signUpMode: !this.state.signUpMode,
+		this.setState(state => {
+			signUpMode: !state.signUpMode,
 		});
 	}
 


### PR DESCRIPTION
En general para cualquier componente, cuando alguna propiedad del estado depende de un estado anterior o props anteriores se debería usar la versión de setState que recibe un callback como parámetro. Esto es debido a que la actualización de estado se realiza de manera asincrónica y podría tomar un valor pasado incorrecto. Así es como se recomienda en la guía del sitio oficial de React.